### PR TITLE
Une erreur? Elle n'etait pas utilise

### DIFF
--- a/collections/universite/universite.use
+++ b/collections/universite/universite.use
@@ -55,7 +55,7 @@ association ProfUni between
 end
 
 association ProfCours between
-	Professeur [1] role professeur
+	Professeur [1] role professeurs
 	Cours [*] role cours
 end
 


### PR DESCRIPTION
`professeur` n'etait pas utilise et je crois aussi que cest possiblement une faute de frappe si on se fit au reste des associations.
```
Professeur [1] role professeur
```
Donc j'ai rajouter le `s`
```
Professeur [1] role professeurs
```